### PR TITLE
Enable import of inspection data into repair plan

### DIFF
--- a/src/utils/inspectionConverter.ts
+++ b/src/utils/inspectionConverter.ts
@@ -1,0 +1,42 @@
+import { Inspection, InventoryItem, ChecklistItem } from '../types';
+
+function mapCondition(condition: ChecklistItem['condition']): InventoryItem['currentCondition'] {
+  switch (condition) {
+    case 'excellent':
+      return 'Excellent';
+    case 'good':
+      return 'Good';
+    case 'fair':
+      return 'Fair';
+    case 'poor':
+      return 'Poor';
+    default:
+      return 'Good';
+  }
+}
+
+export function inspectionToInventoryItems(inspection: Inspection): InventoryItem[] {
+  const items: InventoryItem[] = [];
+
+  inspection.rooms.forEach(room => {
+    room.checklistItems.forEach(check => {
+      const needsAction = check.requiresAction || (check.condition === 'poor') || (check.damageEstimate && check.damageEstimate > 0);
+      if (!needsAction) return;
+
+      const item: InventoryItem = {
+        itemId: `${inspection.id}_${room.id}_${check.id}`,
+        itemName: check.item,
+        category: check.category.toLowerCase(),
+        currentCondition: mapCondition(check.condition),
+        purchaseDate: new Date().toISOString(),
+        originalCost: check.damageEstimate || 0,
+        location: room.name,
+        description: check.notes
+      };
+      items.push(item);
+    });
+  });
+
+  return items;
+}
+


### PR DESCRIPTION
## Summary
- allow `DataInput` to load inspection information
- convert inspection checklist items to inventory format

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68816c196e84832ab639ef7f7cf459e0