### PR TITLE
Add repair plan associations

### DIFF
--- a/src/components/RepairPlan/DataInput.tsx
+++ b/src/components/RepairPlan/DataInput.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useRef } from 'react';
 import { Upload, Plus, FileText, Database, Trash2 } from 'lucide-react';
-import { InventoryItem, SystemConfig, AnalysisResult } from '../../types';
+import { InventoryItem, SystemConfig, AnalysisResult, Inspection } from '../../types';
 import { analyzeInventory } from '../../utils/analysisEngine';
 import { useStorage } from '../../contexts/StorageContext';
 import { inspectionToInventoryItems } from '../../utils/inspectionConverter';
@@ -10,13 +10,15 @@ interface DataInputProps {
   setInventoryData: (data: InventoryItem[]) => void;
   setAnalysisResults: (results: AnalysisResult) => void;
   systemConfig: SystemConfig;
+  onInspectionImported?: (inspection: Inspection) => void;
 }
 
-const DataInput: React.FC<DataInputProps> = ({ 
-  inventoryData, 
-  setInventoryData, 
+const DataInput: React.FC<DataInputProps> = ({
+  inventoryData,
+  setInventoryData,
   setAnalysisResults,
-  systemConfig
+  systemConfig,
+  onInspectionImported
 }) => {
   const [inputMethod, setInputMethod] = useState<'csv' | 'json' | 'manual'>('csv');
   const [newItem, setNewItem] = useState<Partial<InventoryItem>>({
@@ -132,6 +134,9 @@ const DataInput: React.FC<DataInputProps> = ({
     }
 
     setInventoryData([...inventoryData, ...items]);
+    if (onInspectionImported) {
+      onInspectionImported(inspection);
+    }
     setSelectedInspection('');
     setTimeout(() => runAnalysis(), 100);
   };

--- a/src/components/RepairPlan/ReportGenerator.tsx
+++ b/src/components/RepairPlan/ReportGenerator.tsx
@@ -4,9 +4,10 @@ import { FileText, Download, Copy, Check } from 'lucide-react';
 
 interface ReportGeneratorProps {
   analysisResults: AnalysisResult | null;
+  onSavePlan?: () => void;
 }
 
-const ReportGenerator: React.FC<ReportGeneratorProps> = ({ analysisResults }) => {
+const ReportGenerator: React.FC<ReportGeneratorProps> = ({ analysisResults, onSavePlan }) => {
   const [copied, setCopied] = useState(false);
 
   if (!analysisResults) {
@@ -200,7 +201,7 @@ ${item.requiredResources ? item.requiredResources.map(resource => `- ${resource}
           {copied ? <Check className="h-4 w-4 mr-2" /> : <Copy className="h-4 w-4 mr-2" />}
           {copied ? 'Copied!' : 'Copy to Clipboard'}
         </button>
-        
+
         <button
           onClick={downloadReport}
           className="flex items-center px-4 py-2 bg-green-600 text-white rounded-md hover:bg-green-700 transition-colors"
@@ -208,6 +209,15 @@ ${item.requiredResources ? item.requiredResources.map(resource => `- ${resource}
           <Download className="h-4 w-4 mr-2" />
           Download Report
         </button>
+
+        {onSavePlan && (
+          <button
+            onClick={onSavePlan}
+            className="flex items-center px-4 py-2 bg-purple-600 text-white rounded-md hover:bg-purple-700 transition-colors"
+          >
+            Save Repair Plan
+          </button>
+        )}
       </div>
 
       {/* Report Preview */}

--- a/src/contexts/StorageContext.tsx
+++ b/src/contexts/StorageContext.tsx
@@ -1,5 +1,5 @@
 import React, { createContext, useContext, useState, useEffect } from 'react';
-import { Inspection, Property, Report } from '../types';
+import { Inspection, Property, Report, RepairPlan } from '../types';
 import { generateInspectionStructure } from '../utils/inspectionTemplates';
 import { generateInspectionId } from '../utils/idGenerator';
 
@@ -7,11 +7,14 @@ interface StorageContextType {
   inspections: Inspection[];
   properties: Property[];
   reports: Report[];
+  repairPlans: RepairPlan[];
   saveInspection: (inspection: Inspection) => Promise<void>;
   getInspection: (id: string) => Inspection | null;
   deleteInspection: (id: string) => Promise<void>;
   saveProperty: (property: Property) => Promise<void>;
   getProperties: () => Property[];
+  saveRepairPlan: (plan: RepairPlan) => Promise<void>;
+  getRepairPlans: () => RepairPlan[];
   loadData: () => Promise<void>;
 }
 
@@ -29,12 +32,14 @@ export function StorageProvider({ children }: { children: React.ReactNode }) {
   const [inspections, setInspections] = useState<Inspection[]>([]);
   const [properties, setProperties] = useState<Property[]>([]);
   const [reports, setReports] = useState<Report[]>([]);
+  const [repairPlans, setRepairPlans] = useState<RepairPlan[]>([]);
 
   const loadData = async () => {
     try {
       const storedInspections = localStorage.getItem('inspections');
       const storedProperties = localStorage.getItem('properties');
       const storedReports = localStorage.getItem('reports');
+      const storedPlans = localStorage.getItem('repairPlans');
 
       if (storedInspections) {
         setInspections(JSON.parse(storedInspections));
@@ -44,6 +49,9 @@ export function StorageProvider({ children }: { children: React.ReactNode }) {
       }
       if (storedReports) {
         setReports(JSON.parse(storedReports));
+      }
+      if (storedPlans) {
+        setRepairPlans(JSON.parse(storedPlans));
       }
     } catch (error) {
       console.error('Error loading data:', error);
@@ -149,16 +157,28 @@ export function StorageProvider({ children }: { children: React.ReactNode }) {
 
   const getProperties = () => properties;
 
+  const saveRepairPlan = async (plan: RepairPlan) => {
+    const updated = repairPlans.filter(p => p.id !== plan.id);
+    updated.push(plan);
+    setRepairPlans(updated);
+    localStorage.setItem('repairPlans', JSON.stringify(updated));
+  };
+
+  const getRepairPlans = () => repairPlans;
+
   return (
     <StorageContext.Provider value={{
       inspections,
       properties,
       reports,
+      repairPlans,
       saveInspection,
       getInspection,
       deleteInspection,
       saveProperty,
       getProperties,
+      saveRepairPlan,
+      getRepairPlans,
       loadData,
     }}>
       {children}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -81,6 +81,16 @@ export interface Report {
   pdfPath: string;
 }
 
+export interface RepairPlan {
+  id: string;
+  propertyId: string;
+  unitNumber?: number;
+  inspectionId?: string;
+  inventoryData: InventoryItem[];
+  analysisResults: AnalysisResult;
+  createdAt: string;
+}
+
 export interface InventoryItem {
   itemId: string;
   itemName: string;


### PR DESCRIPTION
## Summary
- store repair plans in `StorageContext`
- define `RepairPlan` type
- capture inspection info when importing inventory data
- allow saving repair plans from the report generator
- track selected inspection in the project page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68819600f4c4832aa4d220e57942ab5c