### PR TITLE
Integrate key-check-agent and fix ISO validation

### DIFF
--- a/src/pages/ProjectPage.tsx
+++ b/src/pages/ProjectPage.tsx
@@ -8,9 +8,9 @@ import SystemSettings from '../components/RepairPlan/SystemSettings';
 import { InventoryItem, AnalysisResult, SystemConfig, Inspection, RepairPlan } from '../types';
 import { useStorage } from '../contexts/StorageContext';
 import { generateUniqueId } from '../utils/idGenerator';
-import {PropertyRepairEstimatorAgent} from 'key-check-agent';
+import { estimateRepairCosts } from '../utils/agentIntegration';
 import { OpenAI } from 'openai';
-import{ setDefaultOpenAIKey, setDefaultOpenAIClient } from '@openai/agents';
+import { setDefaultOpenAIClient } from '@openai/agents';
 
 
 function ProjectPage() {
@@ -56,9 +56,9 @@ function ProjectPage() {
       alert('Run analysis before saving the plan');
       return;
     }
-    const agent = await PropertyRepairEstimatorAgent(inventoryData, analysisResults, "US");
-    console.log("Running Property Repair Estimator Agent...");
-    console.log((await agent).overall_project_estimate)
+    console.log('Running Property Repair Estimator Agent...');
+    const estimate = await estimateRepairCosts(analysisResults.flaggedItems, 'US');
+    console.log(estimate.overall_project_estimate);
     const plan: RepairPlan = {
       id: generateUniqueId('plan_'),
       propertyId: currentInspection?.propertyId || 'unknown',
@@ -66,6 +66,7 @@ function ProjectPage() {
       inspectionId: currentInspection?.id,
       inventoryData,
       analysisResults,
+      estimate,
       createdAt: new Date().toISOString(),
     };
     await saveRepairPlan(plan);

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -81,6 +81,27 @@ export interface Report {
   pdfPath: string;
 }
 
+export interface EstimateLine {
+  item_description: string;
+  location: string;
+  issue_type: string;
+  estimated_labor_cost: number;
+  estimated_material_cost: number;
+  item_total_cost: number;
+  repair_instructions: string[];
+  notes?: string;
+}
+
+export interface EstimateResult {
+  overall_project_estimate: number;
+  itemized_breakdown: EstimateLine[];
+  metadata: {
+    creation_date: string;
+    currency: string;
+    disclaimer: string;
+  };
+}
+
 export interface RepairPlan {
   id: string;
   propertyId: string;
@@ -88,6 +109,7 @@ export interface RepairPlan {
   inspectionId?: string;
   inventoryData: InventoryItem[];
   analysisResults: AnalysisResult;
+  estimate?: EstimateResult;
   createdAt: string;
 }
 

--- a/src/utils/agentIntegration.ts
+++ b/src/utils/agentIntegration.ts
@@ -1,0 +1,21 @@
+import { FlaggedItem, EstimateLine, EstimateResult } from '../types';
+import { runRepairEstimatorAgent } from './customRepairEstimator';
+
+export interface InspectionItem {
+  item_description: string;
+  issue_type: string;
+  location_in_property: string;
+  area_identifier?: string;
+}
+
+export async function estimateRepairCosts(
+  flaggedItems: FlaggedItem[],
+  area: string
+): Promise<EstimateResult> {
+  const inspectionData: InspectionItem[] = flaggedItems.map(item => ({
+    item_description: item.itemName,
+    issue_type: item.flagReason,
+    location_in_property: item.location || 'unknown'
+  }));
+  return runRepairEstimatorAgent(inspectionData, area, 'USD');
+}

--- a/src/utils/customRepairEstimator.ts
+++ b/src/utils/customRepairEstimator.ts
@@ -1,0 +1,126 @@
+import OpenAI from 'openai';
+import { Agent, Tool, tool, webSearchTool, run } from '@openai/agents';
+import { InspectionItem, EstimateResult } from './agentIntegration';
+
+const costAgent = new Agent({
+  name: 'Property Repair Cost Estimator',
+  instructions: `You are an expert in estimating repair costs for property inspections.
+    You will receive a list of inspection items with their descriptions, issue types, and locations.
+    Your task is to estimate the labor and material costs for each item, provide step-by-step repair instructions, and return a detailed cost estimate.`,
+  tools: [
+    webSearchTool({
+      userLocation: {
+        type: 'approximate',
+        country: 'US',
+        region: 'Kansas',
+        city: 'Wichita'
+      }
+    })
+  ],
+  model: 'gpt-4o'
+});
+
+const costApiTool: Tool = tool({
+  name: 'get_cost',
+  description: 'Retrieves labor or material cost by performing a web search.',
+  parameters: {
+    type: 'object',
+    properties: {
+      item_description: { type: 'string', description: 'Description of the item' },
+      issue_type: { type: 'string', description: 'Type of issue or repair' },
+      area: { type: 'string', description: 'Area or location for cost estimation' }
+    },
+    required: ['item_description', 'issue_type', 'area'],
+    additionalProperties: true
+  },
+  strict: false,
+  async execute(input: unknown) {
+    if (
+      typeof input === 'object' &&
+      input !== null &&
+      'item_description' in input &&
+      'issue_type' in input &&
+      'area' in input
+    ) {
+      const { item_description, issue_type, area } = input as {
+        item_description: string;
+        issue_type: string;
+        area: string;
+      };
+
+      const results = await run(
+        costAgent,
+        `search for the cost of repairing or replacing a ${item_description} due to ${issue_type} in the area of ${area}. Provide the estimated cost in USD.`
+      );
+      if (Array.isArray(results) && results.length > 0) {
+        const snippet = (results[0] as any).snippet || (results[0] as any).title;
+        const match = snippet.match(/\$?\d{1,3}(?:,\d{3})*(?:\.\d{1,2})?/);
+        if (match) return parseFloat(match[0].replace(/[$,]/g, ''));
+      }
+      return 0;
+    } else {
+      throw new Error('Invalid input: Expected object with item_description, issue_type, and area properties.');
+    }
+  }
+});
+
+const knowledgeBaseTool: Tool = tool({
+  name: 'get_repair_steps',
+  description: 'Fetches step-by-step repair instructions via a web search.',
+  parameters: {
+    type: 'object',
+    properties: {
+      item_description: { type: 'string', description: 'Description of the item' },
+      issue_type: { type: 'string', description: 'Type of issue or repair' }
+    },
+    required: ['item_description', 'issue_type'],
+    additionalProperties: true
+  },
+  strict: false,
+  async execute(input: unknown) {
+    if (
+      typeof input === 'object' &&
+      input !== null &&
+      'item_description' in input &&
+      'issue_type' in input
+    ) {
+      const { item_description, issue_type } = input as {
+        item_description: string;
+        issue_type: string;
+      };
+      const results = await run(
+        costAgent,
+        `search for step-by-step repair instructions for a ${item_description} with the issue type of ${issue_type}. Provide the instructions in a list format.`
+      );
+
+      if (Array.isArray((results as any).output) && (results as any).output.length > 0) {
+        return (results as any).output.slice(0, 3).map((res: any) => res.snippet || res.title);
+      }
+      return ['Standard repair/installation instructions could not be retrieved for this item.'];
+    } else {
+      throw new Error('Invalid input: Expected object with item_description and issue_type properties.');
+    }
+  }
+});
+
+const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+
+const repairEstimatorAgent = new Agent({
+  tools: [costApiTool, knowledgeBaseTool],
+  model: 'gpt-4o',
+  instructions: `You are a property repair cost estimator agent. Your task is to provide accurate cost estimates for property repairs based on inspection data and external information.`,
+  name: 'Property Repair Estimator Agent'
+});
+
+export async function runRepairEstimatorAgent(
+  inspectionData: InspectionItem[],
+  projectArea: string,
+  currency: string = 'USD'
+): Promise<EstimateResult> {
+  const prompt = `Given the following inspection items:\n${JSON.stringify(inspectionData, null, 2)}\nfor the project area: ${projectArea}, provide a detailed repair cost estimate in ${currency}.`;
+  const response = await run(repairEstimatorAgent, prompt);
+  if (response && typeof response === 'object' && 'output' in response) {
+    return (response as any).output as EstimateResult;
+  }
+  return response as EstimateResult;
+}


### PR DESCRIPTION
## Summary
- integrate OpenAI-based repair estimator agent via `estimateRepairCosts`
- add custom agent with US location to satisfy ISO‑3166 code rules
- extend project types with agent estimate result
- use agent output when saving repair plans

## Testing
- `npm install --silent`
- `npm test --silent`
- `npm run lint --silent` *(fails: couldn't find ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_68864c958f44832ab0118929e7ffaadc