### PR TITLE
Add analysis and utility tests

### DIFF
--- a/tests/utils/analysisEngine.test.ts
+++ b/tests/utils/analysisEngine.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from 'vitest';
+import { analyzeInventory } from '../../src/utils/analysisEngine.ts';
+import { InventoryItem, SystemConfig } from '../../src/types';
+
+function withFixedDate<T>(iso: string, fn: () => T): T {
+  const RealDate = Date;
+  const fixed = new RealDate(iso).getTime();
+  class MockDate extends RealDate {
+    constructor(...args: any[]) {
+      if (args.length === 0) {
+        super(fixed);
+      } else {
+        // @ts-ignore
+        super(...args);
+      }
+    }
+    static now() { return fixed; }
+  }
+  // @ts-ignore
+  global.Date = MockDate;
+  try {
+    return fn();
+  } finally {
+    global.Date = RealDate;
+  }
+}
+
+describe('analyzeInventory', () => {
+  it('produces correct counts and costs', () => {
+    withFixedDate('2024-01-01T00:00:00Z', () => {
+      const inventory: InventoryItem[] = [
+      {
+        itemId: '1',
+        itemName: 'Old Outlet',
+        category: 'electrical',
+        currentCondition: 'Damaged',
+        purchaseDate: '2018-01-01T00:00:00Z',
+        lastMaintenanceDate: '2020-01-01T00:00:00Z',
+        originalCost: 1000,
+        currentMarketValue: 800,
+        location: 'Kitchen',
+        description: 'Needs work'
+      },
+      {
+        itemId: '2',
+        itemName: 'Old Pipe',
+        category: 'plumbing',
+        currentCondition: 'Fair',
+        purchaseDate: '2019-06-01T00:00:00Z',
+        lastMaintenanceDate: '2023-01-01T00:00:00Z',
+        originalCost: 1000,
+        currentMarketValue: 1000,
+        location: 'Bathroom',
+        description: ''
+      }
+    ];
+
+    const config: SystemConfig = {
+      repairThreshold: 0.5,
+      laborRates: {
+        general: 50,
+        electrical: 75,
+        plumbing: 65,
+        hvac: 80,
+        specialized: 90
+      },
+      maintenanceThresholds: {
+        general: 24,
+        electrical: 12,
+        plumbing: 18
+      },
+      expectedLifespans: {
+        general: 60,
+        electrical: 60,
+        plumbing: 60
+      }
+    };
+
+    const result = analyzeInventory(inventory, config);
+    expect(result.totalItems).toBe(2);
+    expect(result.flaggedItems.length).toBe(2);
+    expect(result.itemsToFix.length).toBe(1);
+    expect(result.itemsToReplace.length).toBe(1);
+    expect(result.totalEstimatedCost).toBe(1410);
+
+    const [first, second] = result.flaggedItems;
+    expect(first.recommendation).toBe('replace');
+    expect(second.recommendation).toBe('fix');
+    expect(first.estimatedReplacementCost).toBe(1080);
+    expect(second.estimatedRepairCost).toBe(330);
+
+    expect(result.summary).toEqual({
+      conditionFlags: 1,
+      lifecycleFlags: 2,
+      maintenanceFlags: 1
+    });
+    });
+  });
+});

--- a/tests/utils/idGenerator.test.ts
+++ b/tests/utils/idGenerator.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest';
+import { generatePropertyId, generateInspectionId, generateUniqueId } from '../../src/utils/idGenerator.ts';
+
+function withFixedRandom<T>(time: number, rand: number, fn: () => T): T {
+  const realRandom = Math.random;
+  const realDateNow = Date.now;
+  Math.random = () => rand;
+  Date.now = () => time;
+  try {
+    return fn();
+  } finally {
+    Math.random = realRandom;
+    Date.now = realDateNow;
+  }
+}
+
+describe('id generators', () => {
+  it('produce predictable formats', () => {
+    withFixedRandom(0, 0.123456789, () => {
+      const prop = generatePropertyId();
+      expect(prop).toMatch(/^PROP0000004FZZ$/);
+
+      const insp = generateInspectionId(prop, 3);
+      expect(insp).toBe(`${prop}-UNIT03`);
+
+      const uid = generateUniqueId('PRE_');
+      expect(uid).toMatch(/^PRE_0_4fzzzxjyl$/);
+    });
+  });
+});

--- a/tests/utils/inspectionConverter.test.ts
+++ b/tests/utils/inspectionConverter.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest';
+import { inspectionToInventoryItems } from '../../src/utils/inspectionConverter.ts';
+import { Inspection } from '../../src/types';
+
+function withFixedDate<T>(iso: string, fn: () => T): T {
+  const RealDate = Date;
+  const fixed = new RealDate(iso).getTime();
+  class MockDate extends RealDate {
+    constructor(...args: any[]) {
+      if (args.length === 0) {
+        super(fixed);
+      } else {
+        // @ts-ignore
+        super(...args);
+      }
+    }
+    static now() { return fixed; }
+  }
+  // @ts-ignore
+  global.Date = MockDate;
+  try {
+    return fn();
+  } finally {
+    global.Date = RealDate;
+  }
+}
+
+describe('inspectionToInventoryItems', () => {
+  it('converts checklist items to inventory entries', () => {
+    withFixedDate('2024-01-01T00:00:00Z', () => {
+    const inspection: Inspection = {
+      id: 'INSP1',
+      propertyId: 'PROP1',
+      type: 'move-in',
+      status: 'completed',
+      createdAt: '2023-12-01T00:00:00Z',
+      inspector: { id: '1', name: 'Inspector', email: 'i@example.com', role: 'property_manager' },
+      rooms: [
+        {
+          id: 'room1',
+          name: 'Kitchen',
+          type: 'kitchen',
+          checklistItems: [
+            { id: 'c1', category: 'Electrical', item: 'Outlet', condition: 'poor', notes: 'broken', photos: [], requiresAction: true },
+            { id: 'c2', category: 'Plumbing', item: 'Sink', condition: 'good', notes: '', photos: [], damageEstimate: 50, requiresAction: false }
+          ]
+        }
+      ],
+      generalNotes: '',
+      signatures: [],
+      reportGenerated: false,
+      syncStatus: 'synced'
+    } as unknown as Inspection;
+
+    const items = inspectionToInventoryItems(inspection);
+    expect(items.length).toBe(2);
+    expect(items[0].itemName).toBe('Outlet');
+    expect(items[0].category).toBe('electrical');
+    expect(items[0].currentCondition).toBe('Poor');
+    expect(items[1].itemName).toBe('Sink');
+    expect(items[1].category).toBe('plumbing');
+    expect(items[1].currentCondition).toBe('Good');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add analysisEngine tests with fixed data
- add inspectionConverter conversion tests
- add idGenerator format tests

## Testing
- `node --loader ts-node/esm --test tests/rateLimiter.test.ts`
- `npx vitest run tests/utils/analysisEngine.test.ts` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*

------
https://chatgpt.com/codex/tasks/task_e_68879c9ff0b0832aa1ec490dfc230f43