### PR TITLE
Remove redundant estimator code

### DIFF
--- a/src/utils/analysisEngine.ts
+++ b/src/utils/analysisEngine.ts
@@ -1,5 +1,11 @@
-import { InventoryItem, FlaggedItem, AnalysisResult, SystemConfig } from '../types';
-import { generateDetailedRepairEstimate, UserLocation } from './customRepairEstimator';
+import {
+  InventoryItem,
+  FlaggedItem,
+  AnalysisResult,
+  SystemConfig,
+  UserLocation
+} from '../types';
+import { generateDetailedRepairEstimate } from './customRepairEstimator';
 
 export const analyzeInventoryAndGeneratePlan = async (
   inventory: InventoryItem[],

--- a/src/utils/customRepairEstimator.ts
+++ b/src/utils/customRepairEstimator.ts
@@ -1,161 +1,15 @@
 import OpenAI from 'openai';
-import { Agent, Tool, tool, webSearchTool, run, setDefaultOpenAIClient } from '@openai/agents';
-import { InventoryItem, EstimateResult, EstimateLine } from '../types';
+import { Agent, run, setDefaultOpenAIClient } from '@openai/agents';
+import {
+  InventoryItem,
+  EstimateResult,
+  EstimateLine,
+  UserLocation,
+  EstimateLineItem,
+  DetailedEstimate
+} from '../types';
+import { createRepairEstimatorAgent } from '../agent/repairEstimateAgents';
 
-export interface UserLocation {
-  city: string;
-  region: string;
-  country: string;
-  type: 'approximate';
-}
-
-export interface EstimateLineItem {
-  item_description: string;
-  location: string;
-  issue_type: string;
-  recommendation: 'fix' | 'replace';
-  repair_costs: {
-    labor_cost: number;
-    material_cost: number;
-    total_cost: number;
-  };
-  replacement_costs: {
-    labor_cost: number;
-    material_cost: number;
-    total_cost: number;
-  };
-  recommended_option: {
-    action: 'fix' | 'replace';
-    labor_cost: number;
-    material_cost: number;
-    total_cost: number;
-    cost_savings?: number;
-  };
-  repair_steps: string[];
-  notes?: string;
-}
-
-export interface DetailedEstimate {
-  line_items: EstimateLineItem[];
-  summary: {
-    total_labor_cost: number;
-    total_material_cost: number;
-    total_project_cost: number;
-    items_to_repair: number;
-    items_to_replace: number;
-  };
-  metadata: {
-    user_location: UserLocation;
-    currency: string;
-    generated_date: string;
-    disclaimer: string;
-  };
-}
-
-const createCostSearchTool = (userLocation: UserLocation): Tool => tool({
-  name: 'search_labor_costs',
-  description: 'Search for current labor rates for specific repair work in the user location.',
-  parameters: {
-    type: 'object',
-    properties: {
-      work_type: { type: 'string', description: 'Type of work (e.g., electrical repair, plumbing fix, HVAC maintenance)' },
-      trade: { type: 'string', description: 'Trade category (electrician, plumber, HVAC tech, general contractor)' },
-      complexity: { type: 'string', description: 'Complexity level (basic, intermediate, advanced)' }
-    },
-    required: ['work_type', 'trade', 'complexity'],
-    additionalProperties: false
-  },
-  strict: true,
-  async execute(input: unknown) {
-    const { work_type, trade, complexity } = input as {
-      work_type: string;
-      trade: string;
-      complexity: string;
-    };
-
-    const searchAgent = new Agent({
-      name: 'Labor Cost Researcher',
-      instructions: `Search for current labor rates for ${trade} performing ${work_type} in ${userLocation.city}, ${userLocation.region}. 
-      Look for hourly rates, minimum charges, and typical costs for ${complexity} level work. 
-      Return specific dollar amounts and cite sources when possible.`,
-      tools: [webSearchTool({ userLocation })],
-      model: 'gpt-4.1-mini'
-    });
-
-    const query = `${trade} hourly rates ${work_type} ${userLocation.city} ${userLocation.region} 2024 2025 labor costs`;
-    return await run(searchAgent, query);
-  }
-});
-
-const createMaterialCostTool = (userLocation: UserLocation): Tool => tool({
-  name: 'search_material_costs',
-  description: 'Search for current material and parts costs in the user location.',
-  parameters: {
-    type: 'object',
-    properties: {
-      item_type: { type: 'string', description: 'Type of material or part needed' },
-      category: { type: 'string', description: 'Category (electrical, plumbing, HVAC, building materials)' },
-      quality_level: { type: 'string', description: 'Quality level (basic, standard, premium)' }
-    },
-    required: ['item_type', 'category', 'quality_level'],
-    additionalProperties: false
-  },
-  strict: true,
-  async execute(input: unknown) {
-    const { item_type, category, quality_level } = input as {
-      item_type: string;
-      category: string;
-      quality_level: string;
-    };
-
-    const searchAgent = new Agent({
-      name: 'Material Cost Researcher',
-      instructions: `Search for current prices of ${item_type} in ${category} category, ${quality_level} quality level in ${userLocation.city}, ${userLocation.region}. 
-      Look for prices from major retailers (Home Depot, Lowe's, local suppliers). 
-      Return specific price ranges and typical costs.`,
-      tools: [webSearchTool({ userLocation })],
-      model: 'gpt-4.1-mini'
-    });
-
-    const query = `${item_type} ${category} price cost ${userLocation.city} ${userLocation.region} Home Depot Lowes supplier 2024 2025`;
-    return await run(searchAgent, query);
-  }
-});
-
-const createRepairInstructionsTool = (userLocation: UserLocation): Tool => tool({
-  name: 'search_repair_instructions',
-  description: 'Search for detailed repair and installation instructions.',
-  parameters: {
-    type: 'object',
-    properties: {
-      item_description: { type: 'string', description: 'Description of the item to repair/replace' },
-      action_type: { type: 'string', description: 'Type of action (repair, replace, install)' },
-      issue_type: { type: 'string', description: 'Specific issue or problem' }
-    },
-    required: ['item_description', 'action_type', 'issue_type'],
-    additionalProperties: false
-  },
-  strict: true,
-  async execute(input: unknown) {
-    const { item_description, action_type, issue_type } = input as {
-      item_description: string;
-      action_type: string;
-      issue_type: string;
-    };
-
-    const searchAgent = new Agent({
-      name: 'Repair Instructions Researcher',
-      instructions: `Search for step-by-step instructions to ${action_type} a ${item_description} with ${issue_type}. 
-      Look for professional guides, manufacturer instructions, and industry best practices. 
-      Return detailed, sequential steps that are safe and code-compliant.`,
-      tools: [webSearchTool({ userLocation })],
-      model: 'gpt-4.1'
-    });
-
-    const query = `how to ${action_type} ${item_description} ${issue_type} step by step instructions professional guide`;
-    return await run(searchAgent, query);
-  }
-});
 
 // @ts-ignore - Vite env variables can be undefined
 const apiKey: string | undefined = import.meta.env.VITE_OPENAI_API_KEY;
@@ -164,36 +18,6 @@ if (!apiKey || typeof apiKey !== 'string') {
 }
 const openai = new OpenAI({ apiKey, dangerouslyAllowBrowser: true });
 setDefaultOpenAIClient(openai);
-
-const createRepairEstimatorAgent = (userLocation: UserLocation) => {
-  return new Agent({
-    name: 'Advanced Property Repair Cost Estimator',
-    instructions: `You are a comprehensive property repair cost estimation agent specializing in accurate market-based pricing for ${userLocation.city}, ${userLocation.region}.
-
-Your responsibilities:
-1. Analyze each inventory item to determine whether repair or replacement is more cost-effective
-2. Search for current local labor rates and material costs using real market data
-3. Provide detailed step-by-step repair/replacement instructions
-4. Generate comprehensive cost breakdowns with labor, materials, and total costs
-5. Recommend the most cost-effective approach for each item
-
-For each item, you must:
-- Search current labor rates for the specific trade (electrician, plumber, HVAC tech, general contractor)
-- Search current material/parts costs from local suppliers
-- Compare repair vs replacement costs
-- Recommend the most economical option
-- Provide detailed repair or installation steps
-
-Format your response as a structured analysis with clear cost breakdowns and recommendations.`,
-    tools: [
-      createCostSearchTool(userLocation),
-      createMaterialCostTool(userLocation),
-      createRepairInstructionsTool(userLocation),
-      webSearchTool({ userLocation: { ...userLocation, type: 'approximate' } })
-    ],
-    model: 'o4-mini'
-  });
-};
 
 export async function generateDetailedRepairEstimate(
   inventoryItems: InventoryItem[],

--- a/src/utils/repairEstimatorExample.ts
+++ b/src/utils/repairEstimatorExample.ts
@@ -1,5 +1,5 @@
-import { generateDetailedRepairEstimate, UserLocation, EstimateLineItem } from './customRepairEstimator';
-import { InventoryItem } from '../types';
+import { generateDetailedRepairEstimate } from './customRepairEstimator';
+import { InventoryItem, UserLocation, EstimateLineItem } from '../types';
 
 // Example usage of the refactored repair estimator
 export async function exampleRepairEstimate() {


### PR DESCRIPTION
## Summary
- delete locally defined interfaces and tools in `customRepairEstimator`
- use shared agent and types from `../agent` and `../types`
- update dependent utils to import types from `../types`

## Testing
- `npm test` *(fails: Cannot find module '@rollup/rollup-linux-x64-gnu')*
- `npm run lint` *(fails: couldn't find ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_688b082110e4832aad808d9f9b6bfd6e