### PR TITLE
Integrate estimation service

### DIFF
--- a/src/agent/repairEstimateAgents.ts
+++ b/src/agent/repairEstimateAgents.ts
@@ -3,7 +3,7 @@ import { Agent, webSearchTool } from '@openai/agents';
 import { UserLocation } from '../types';
 import { createLaborCostTool } from '../tools/laborCostTool';
 import { createMaterialCostTool } from '../tools/materialCostTool';
-import { createRepairInstructionsTool } from '../tools/repairInstructionsTool';
+import { createRepairInstructionsTool } from '../tools/repairInstructionTool';
 
 export function createRepairEstimatorAgent(userLocation: UserLocation): Agent {
   return new Agent({


### PR DESCRIPTION
## Summary
- connect `generateEstimate` service with `ProjectPage`
- clean up redundant OpenAI setup
- fix repair estimator agent import path

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688cb7704fbc832a9c2b5c58ef0f18de