### PR TITLE
Remove Generate Report on save

### DIFF
--- a/src/components/RepairPlan/ReportGenerator.tsx
+++ b/src/components/RepairPlan/ReportGenerator.tsx
@@ -4,10 +4,9 @@ import { FileText, Download, Copy, Check } from 'lucide-react';
 
 interface ReportGeneratorProps {
   analysisResults: AnalysisResult | null;
-  onSavePlan?: () => void;
 }
 
-const ReportGenerator: React.FC<ReportGeneratorProps> = ({ analysisResults, onSavePlan }) => {
+const ReportGenerator: React.FC<ReportGeneratorProps> = ({ analysisResults }) => {
   const [copied, setCopied] = useState(false);
 
   if (!analysisResults) {
@@ -210,14 +209,7 @@ ${item.requiredResources ? item.requiredResources.map(resource => `- ${resource}
           Download Report
         </button>
 
-        {onSavePlan && (
-          <button
-            onClick={onSavePlan}
-            className="flex items-center px-4 py-2 bg-purple-600 text-white rounded-md hover:bg-purple-700 transition-colors"
-          >
-            Save Repair Plan
-          </button>
-        )}
+        {/* Save functionality removed */}
       </div>
 
       {/* Report Preview */}


### PR DESCRIPTION
## Summary
- remove save plan functionality from ReportGenerator component
- streamline ProjectPage by dropping Generate Report save handler and inspection state

## Testing
- `npm test` *(fails: Backend not available; transform errors)*
- `npm run test:e2e` *(fails: Missing script)*
- `npx vitest run --coverage` *(fails: Cannot find dependency '@vitest/coverage-v8')*

------
https://chatgpt.com/codex/tasks/task_e_68a8b49b2e48832a827526208dca0251